### PR TITLE
fix: maximize inline sidecar according to the left and right constrainsts of a repl-output

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Sidecar/Nested.scss
+++ b/plugins/plugin-client-common/web/scss/components/Sidecar/Nested.scss
@@ -35,8 +35,8 @@
 @include NestedSidecar {
   @include Maximized {
     position: absolute;
-    left: 0;
-    right: 0;
+    left: calc(#{$input-padding-left} + #{$repl-context-min-width} + #{$repl-context-margin-right});
+    right: $input-padding-right;
     top: 3rem;
     bottom: 0;
     height: calc(100% - 3rem);

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -29,7 +29,7 @@ $focus-color: var(--color-brand-01);
 .repl-input,
 .repl-input-sourceref,
 .repl-output {
-  padding-right: calc(1rem - 6px);
+  padding-right: $input-padding-right;
 }
 
 @mixin show-block-action-buttons {
@@ -239,7 +239,7 @@ body[kui-theme-style='dark'] {
     .repl-input,
     .repl-input-sourceref,
     .repl-output {
-      padding-left: 1rem;
+      padding-left: $input-padding-left;
     }
     .repl-input .kui--toolbar-button-with-icon {
       /* have buttons fit inside the input region */
@@ -250,9 +250,9 @@ body[kui-theme-style='dark'] {
       display: flex;
       justify-content: flex-end;
       flex-basis: 3rem;
-      min-width: 3rem;
+      min-width: $repl-context-min-width;
       text-align: end;
-      margin-right: 0.5rem;
+      margin-right: $repl-context-margin-right;
       position: relative;
       opacity: 0.75;
     }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -20,6 +20,11 @@ $input-bg-minisplit: var(--color-base01);
 $input-border: rgba(100, 100, 100, 0.05);
 $input-border-editing: var(--color-brand-03);
 
+$input-padding-right: calc(1rem - 6px);
+$input-padding-left: 1rem;
+$repl-context-min-width: 3rem;
+$repl-context-margin-right: 0.5rem;
+
 /** Hover hysteresis for showing action buttons */
 $action-hover-delay: 210ms;
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
