### PR TITLE
fix: commands can register evaluator option so core/repl will not redirect output

### DIFF
--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -89,6 +89,9 @@ export interface CommandOptions extends CapabilityRequirements {
   plugin?: string
   okOptions?: string[]
 
+  /** controller wants to handle redirect */
+  noCoreRedirect?: boolean
+
   /** model to view transformer */
   viewTransformer?: ViewTransformer<KResponse, ParsedOptions>
 

--- a/plugins/plugin-bash-like/fs/src/lib/fwrite.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/fwrite.ts
@@ -21,7 +21,7 @@ export async function _fwrite(_fullpath: string, data: string | Buffer) {
   const { mkdir, writeFile } = await import('fs')
   const fullpath = _fullpath.replace(/"/g, '') // trim double quotes
 
-  return new Promise<boolean>((resolve, reject) => {
+  await new Promise<boolean>((resolve, reject) => {
     const write = (path: string, data: string | Buffer) =>
       writeFile(path, data, err => {
         if (err) {
@@ -57,7 +57,8 @@ const fwrite = async ({ argvNoOptions, execOptions }: Arguments) => {
   const fullpath = argvNoOptions[1]
   const data = execOptions.data as string | Buffer
 
-  return _fwrite(fullpath, data)
+  await _fwrite(fullpath, data)
+  return true
 }
 
 async function fwriteTemp(args: Arguments): Promise<RawResponse<string>> {

--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -100,7 +100,7 @@ export interface VFS {
   fslice(filename: string, offset: number, length: number): Promise<string>
 
   /** write data to file */
-  fwrite(opts: Pick<Arguments, 'REPL'>, fullpath: string, data: string | Buffer): Promise<boolean>
+  fwrite(opts: Pick<Arguments, 'REPL'>, fullpath: string, data: string | Buffer): Promise<void>
 
   /** Create a directory/bucket */
   mkdir(

--- a/plugins/plugin-bash-like/fs/src/vfs/local.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/local.ts
@@ -71,11 +71,7 @@ class LocalVFS implements VFS {
   }
 
   /** Write data to a files */
-  public async fwrite(
-    opts: Pick<Arguments, 'REPL'>,
-    filepath: string,
-    data: string | Buffer
-  ): Promise<boolean> {
+  public async fwrite(opts: Pick<Arguments, 'REPL'>, filepath: string, data: string | Buffer): Promise<void> {
     return _fwrite(filepath, data)
   }
 

--- a/plugins/plugin-client-common/src/controller/commentary.ts
+++ b/plugins/plugin-client-common/src/controller/commentary.ts
@@ -134,5 +134,5 @@ async function addComment(args: Arguments<CommentaryOptions>): Promise<true | Co
  */
 export default async (commandTree: Registrar) => {
   commandTree.listen('/commentary', addComment, { usage, outputOnly: true })
-  commandTree.listen('/#', addComment, { usage, outputOnly: true })
+  commandTree.listen('/#', addComment, { usage, outputOnly: true, noCoreRedirect: true })
 }

--- a/plugins/plugin-client-test/src/lib/cmds/pipe-stage-parsing.ts
+++ b/plugins/plugin-client-test/src/lib/cmds/pipe-stage-parsing.ts
@@ -23,15 +23,19 @@ interface Options extends ParsedOptions {
 }
 
 export default function(registrar: Registrar) {
-  registrar.listen<string, Options>('/kuiPipeStageParsing', args => {
-    const { stage = 0, prefix, redirect } = args.parsedOptions
+  registrar.listen<string, Options>(
+    '/kuiPipeStageParsing',
+    args => {
+      const { stage = 0, prefix, redirect } = args.parsedOptions
 
-    if (prefix) {
-      return args.pipeStages.prefix || 'nope'
-    } else if (redirect) {
-      return args.pipeStages.redirect || 'nope'
-    } else {
-      return args.pipeStages.stages[stage].join(' ')
-    }
-  })
+      if (prefix) {
+        return args.pipeStages.prefix || 'nope'
+      } else if (redirect) {
+        return args.pipeStages.redirect || 'nope'
+      } else {
+        return args.pipeStages.stages[stage].join(' ')
+      }
+    },
+    { noCoreRedirect: true }
+  )
 }

--- a/plugins/plugin-core-support/src/notebooks/vfs/index.ts
+++ b/plugins/plugin-core-support/src/notebooks/vfs/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import TrieSearch from 'trie-search'
 import micromatch from 'micromatch'
 import { basename, dirname, join } from './posix'
@@ -242,13 +243,8 @@ export class NotebookVFS implements VFS {
     }
   }
 
-  public async fwrite(
-    opts: Pick<Arguments, 'REPL'>,
-    filepath: string,
-    data: string | Buffer
-  ) {
-    console.error('Unsupported operation')
-    return false
+  public async fwrite(opts: Pick<Arguments, 'REPL'>, filepath: string, data: string | Buffer) {
+    throw new Error('Unsupported operation')
   }
 
   /** Fetch content slice */


### PR DESCRIPTION
Also improves the error handling of core redirect

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
