### PR TITLE
fix(plugins/plugin-kubectl): lazily load jsonpath npm

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/custom-columns.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/custom-columns.ts
@@ -134,7 +134,7 @@ export function toKuiTableForUpdateFromCustomColumns(
 }
 
 /** See ./get.ts; it will send full table (as KubeItems) here for parsing */
-export default function toKuiTable(
+export function toKuiTableFromCustomColumns(
   list: KubeResource | KubeItems,
   args: Pick<Arguments<KubeOptions>, 'parsedOptions'>,
   drilldownCommand: string,
@@ -158,3 +158,5 @@ export default function toKuiTable(
     resourceVersion: list.metadata.resourceVersion
   })
 }
+
+export default toKuiTableFromCustomColumns

--- a/plugins/plugin-kubectl/src/controller/client/direct/get.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/get.ts
@@ -37,7 +37,6 @@ import {
 import columnsOf from './columns'
 import { urlFormatterFor } from './url'
 import handleErrors, { tryParseAsStatus } from './errors'
-import toKuiTableFromCustomColumns from './custom-columns'
 import { headersForPlainRequest, headersForTableRequest } from './headers'
 import { isStatus, KubeItems, MetaTable } from '../../../lib/model/resource'
 
@@ -87,7 +86,13 @@ export async function getTable(
       }, undefined)
 
       list.isKubeResource = true
-      const table = toKuiTableFromCustomColumns(list, args, drilldownCommand, kind, fmt)
+      const table = (await import('./custom-columns')).toKuiTableFromCustomColumns(
+        list,
+        args,
+        drilldownCommand,
+        kind,
+        fmt
+      )
       return !isWatchRequest(args) ? table : makeWatchable(drilldownCommand, args, kind, group, table, formatUrl)
     } else {
       // assemble the non-errors into a single table

--- a/plugins/plugin-kubectl/src/controller/client/direct/watch.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/watch.ts
@@ -20,7 +20,6 @@ import { Abortable, Arguments, Row, Suspendable, Table, Watchable, Watcher, Watc
 import { Group, isObjectInGroup } from './group'
 import columnsOf from './columns'
 import URLFormatter from './url'
-import { toKuiTableForUpdateFromCustomColumns } from './custom-columns'
 import { headersForPlainRequest, headersForTableRequest } from './headers'
 
 import { FinalState } from '../../../lib/model/states'
@@ -292,7 +291,7 @@ export class SingleKindDirectWatcher extends DirectWatcher implements Abortable,
   }
 
   /** This will be called whenever the streamer has data for us. */
-  private onData(update: WatchUpdate) {
+  private async onData(update: WatchUpdate) {
     if (!update.object.columnDefinitions && this.bodyColumnDefinitions) {
       update.object.columnDefinitions = this.bodyColumnDefinitions
     }
@@ -317,7 +316,7 @@ export class SingleKindDirectWatcher extends DirectWatcher implements Abortable,
     }
 
     const table = custo
-      ? toKuiTableForUpdateFromCustomColumns(
+      ? (await import('./custom-columns')).toKuiTableForUpdateFromCustomColumns(
           (update.object as any) as KubeResource,
           this.args,
           this.drilldownCommand,


### PR DESCRIPTION
Fixes #7231

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
